### PR TITLE
ルーレット確定後、リトライとやめるを選べるようにした。

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,7 +25,7 @@ module.exports = {
         'plugin:react-hooks/recommended', // React hooks rules
         'plugin:jsx-a11y/recommended', // Accessibility rules
         'prettier/@typescript-eslint', // Prettier plugin
-        'plugin:prettier/recommended', // Prettier recommended rules 
+        'plugin:prettier/recommended', // Prettier recommended rules
       ],
       rules: {
         // We will use TypeScript's types for component props instead
@@ -40,8 +40,12 @@ module.exports = {
         // Why would you want unused vars?
         '@typescript-eslint/no-unused-vars': ['error'],
 
-        "@typescript-eslint/explicit-function-return-type": "off",
-        "@typescript-eslint/explicit-module-boundary-types": "off",
+        '@typescript-eslint/explicit-function-return-type': 'off',
+        '@typescript-eslint/explicit-module-boundary-types': 'off',
+        '@typescript-eslint/consistent-type-assertions': [
+          'error',
+          { assertionStyle: 'as', objectLiteralTypeAssertions: 'allow-as-parameter' },
+        ],
         'prettier/prettier': ['error', {}, { usePrettierrc: true }], // Includes .prettierrc.js rules
       },
     },

--- a/src/components/HycText.tsx
+++ b/src/components/HycText.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import styled from 'styled-components'
+
+import useHyc from '../hooks/useHyc'
+const Root = styled.span``
+
+const HycText: React.VFC = () => {
+  const { hyc } = useHyc()
+
+  return <Root>{hyc}HYC</Root>
+}
+export default HycText

--- a/src/contexts/HycContext.tsx
+++ b/src/contexts/HycContext.tsx
@@ -1,0 +1,37 @@
+import React, { createContext, useEffect, useState } from 'react'
+
+interface ContextProps {
+  hyc: number
+  setHyc: React.Dispatch<React.SetStateAction<number>>
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+export const HycContext = createContext({ hyc: 0, setHyc: () => {} } as ContextProps)
+
+const HycContextProvider = ({ children }) => {
+  const [hyc, setHyc] = useState<number>(0)
+  useEffect(() => {
+    if (!window) return
+    if (!hyc) return
+    window.localStorage.setItem('club.peachgang.hyc', `${hyc}`)
+  }, [hyc])
+
+  useEffect(() => {
+    if (!window) return
+    const h = +(
+      (window.localStorage.getItem('club.peachgang.hyc') ||
+        window.localStorage.getItem('club.peachgung.hyc')) ??
+      0
+    )
+    if (h === Infinity) {
+      alert('ハッキングやめてください')
+      setHyc(-99999999)
+      return
+    }
+    setHyc(h)
+  }, [])
+
+  return <HycContext.Provider value={{ hyc, setHyc }}>{children}</HycContext.Provider>
+}
+
+export default HycContextProvider

--- a/src/hooks/useHyc.ts
+++ b/src/hooks/useHyc.ts
@@ -1,0 +1,8 @@
+import { useContext } from 'react'
+import { HycContext } from '../contexts/HycContext'
+
+const useHyc = () => {
+  return useContext(HycContext)
+}
+
+export default useHyc

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -4,11 +4,12 @@ import { ThemeProvider } from 'styled-components'
 import { theme } from '../styles/theme'
 import '../styles/global.css'
 import ReactGA from 'react-ga'
+import HycContextProvider from '../contexts/HycContext'
 ReactGA.initialize('UA-48876391-9')
 const App = ({ Component, pageProps }: AppProps) => (
   <>
     <Head>
-      <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+      <meta name="viewport" content="width=device-width, initial-scale=0.9, shrink-to-fit=no" />
       <link rel="shortcut icon" href="/images/peachick.png" key="shortcutIcon" />
       <link rel="preconnect" href="https://fonts.gstatic.com" />
       <link
@@ -21,7 +22,9 @@ const App = ({ Component, pageProps }: AppProps) => (
       />
     </Head>
     <ThemeProvider theme={theme}>
-      <Component {...pageProps} />
+      <HycContextProvider>
+        <Component {...pageProps} />
+      </HycContextProvider>
     </ThemeProvider>
   </>
 )

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -15,6 +15,7 @@ import ActionIcon from '../components/AcionIcon'
 import Roulette from '../components/Roulette'
 import ReactGA from 'react-ga'
 import Retrogame from '../components/actions/Retrogame'
+import HycText from '../components/HycText'
 
 type StyledProps = {
   isNight: boolean
@@ -66,11 +67,6 @@ const IndexPage: React.FC = () => {
 
   const [rotate, setRotate] = useState<number>(0)
   const [commandText, setCommandText] = useState<string>('')
-  const [hyc, setHyc] = useState<number>(0)
-  useEffect(() => {
-    if (!hyc) return
-    window.localStorage.setItem('club.peachgung.hyc', `${hyc}`)
-  }, [hyc])
   useEffect(() => {
     fetch(
       'https://docs.google.com/spreadsheets/d/e/2PACX-1vR04bDEoPZUExwsnXZsxzDx5Ii09DM_U4IanJD-NASu1yrXyp_rYp6EGUuiUsSYF-3rwwlBwzTPEqQi/pub?output=csv'
@@ -94,16 +90,7 @@ const IndexPage: React.FC = () => {
       })
     })
   }, [commandInputIsOpen])
-  useEffect(() => {
-    const h = +(window.localStorage.getItem('club.peachgung.hyc') ?? 0)
-    if (h === Infinity) {
-      alert('ハッキングやめてください')
-      setHyc(-99999999)
-      return
-    }
-    window.localStorage.setItem('club.peachgung.hyc', `${h}`)
-    setHyc(h)
-  }, [])
+
   const handleClickPeachGang = () => {
     setCommandInputIsOpen(true)
   }
@@ -128,7 +115,6 @@ const IndexPage: React.FC = () => {
         break
       case 'roulette':
         setIsOpenRoulette(true)
-        setHyc(hyc - 10)
         break
       case 'retrogame':
         setIsOpenRetrogame(true)
@@ -153,7 +139,11 @@ const IndexPage: React.FC = () => {
         url={'/'}
       />
       <div>
-        {commandInputIsOpen && <ActionHeader>{hyc} HYC</ActionHeader>}
+        {commandInputIsOpen && (
+          <ActionHeader>
+            <HycText />
+          </ActionHeader>
+        )}
         <ActionContainer isNight={isNight}>
           {commandInputIsOpen && (
             <>
@@ -218,8 +208,7 @@ const IndexPage: React.FC = () => {
       </div>
       {isOpenRoulette && (
         <Roulette
-          onFinish={(reward) => {
-            setHyc(hyc + reward)
+          onFinish={() => {
             setIsOpenRoulette(false)
           }}
         />


### PR DESCRIPTION
- ルーレット結果確定後、自動で終了しないようにした。
  - リトライとやめるを選べるようにした。
  - 「今すぐ購入」ボタンのスタイルの特別感を高めた。
- HYCの参照と操作のリファクタ
  - useHycで扱えるようにした。
![スクリーンショット 2021-02-20 205202](https://user-images.githubusercontent.com/1734095/108594468-87d79d80-73bd-11eb-8ea7-7bd3f8c4da0e.png)
